### PR TITLE
fix error of libcurl

### DIFF
--- a/CN/atilo_cn
+++ b/CN/atilo_cn
@@ -57,8 +57,9 @@ function check_for_req()
 
 	if [ ! -z "$requirements" ]; then
 		tips "[ 正在安装依赖项 ]"
-        apt update
-		apt install ${requirements} -y
+		pkg install ${requirements} libcurl -y
+    else
+			pkg install libcurl -y
 	fi
 }
 

--- a/atilo
+++ b/atilo
@@ -57,7 +57,9 @@ function check_for_req()
 
     if [ ! -z "$requirements" ]; then
         tips "[ Installing requirements ... ]"
-        pkg update && pkg install ${requirements} -y
+        pkg install ${requirements} libcurl -y
+    else
+			pkg install libcurl -y
     fi
 }
 


### PR DESCRIPTION
看来很多人是把atilo当成那种装机必备的东西了

Termux官方bootstrap包的libcurl太老了，API改动导致curl出现错误