### PR TITLE
Remove duplicated arguments

### DIFF
--- a/CN/atilo_cn
+++ b/CN/atilo_cn
@@ -292,9 +292,6 @@ def run_image(arg):
     command += ' --link2symlink'
     command += ' -S '
     command += distro_path
-    command += ' -b /sys'
-    command += ' -b /dev'
-    command += ' -b /proc'
 #   command += ' -b /sdcard'
 #   command += ' -b /system'
 #   command += ' -b /data/data/com.termux/files/home'

--- a/atilo
+++ b/atilo
@@ -275,9 +275,6 @@ def run_image(arg):
     command += ' --link2symlink'
     command += ' -S '
     command += distro_path
-    command += ' -b /sys'
-    command += ' -b /dev'
-    command += ' -b /proc'
 #   command += ' -b /sdcard'
 #   command += ' -b /system'
 #   command += ' -b /data/data/com.termux/files/home'


### PR DESCRIPTION
[proot的文档](https://github.com/termux/proot/blob/master/doc/proot/manual.txt#L206)：
```markdown
-S path
    Alias: `-0 -r *path*` + a couple of recommended `-b`.

    This option is useful to safely create and install packages into
    the guest rootfs.  It is similar to the `-R` option expect it
    enables the `-0` option and binds only the following minimal set
    of paths to avoid unexpected changes on host files:

    * /etc/host.conf
    * /etc/hosts
    * /etc/nsswitch.conf
    * /etc/resolv.conf
    * /dev/
    * /sys/
    * /proc/
    * /tmp/
    * /run/shm
    * $HOME
    * *path*
```