### PR TITLE
自动识别Linux发行版默认shell

### DIFF
--- a/atilo
+++ b/atilo
@@ -289,7 +289,18 @@ def run_image(arg):
     if 'shell' in infos.keys():
         command += infos.get('shell')
     else:
-        command += 'bash'
+        with open(distro_path+"/etc/passwd") as f:
+            passwd_dict={}
+            for line in f:
+                args = line.split(":")
+                passwd_dict[args[0]]=args[6]
+
+            shell=passwd_dict['root'].strip().split('/')
+            if (shell[-1] != '' and len(shell[-1]) != 0):
+                command += shell[-1]
+            else:
+                command += 'bash'
+
     command += ' --login'
     if len(arg) > 1:
         ext_com = ' '.join(arg[1:])


### PR DESCRIPTION
目前已知可已在"local.json"文件中添加shell值来指定打开的shell
手动添加方式或许有些繁琐

我们可以通过读取/etc/passwd文件来得到root用户当前默认的shell，
这样当我们在发行版中通过chsh切换了默认shell后，也不需要手动修改"local.json"中的值。

Power Power 生产力+1🥳